### PR TITLE
Attach CloudWatchLogsFullAccess policy to IAM role

### DIFF
--- a/setup/setupEnvironment.sh
+++ b/setup/setupEnvironment.sh
@@ -71,6 +71,7 @@ aws iam create-role --role-name ${ROLE_NAME} --assume-role-policy-document file:
 aws iam attach-role-policy --role-name ${ROLE_NAME} --policy-arn arn:aws:iam::aws:policy/AmazonESFullAccess
 aws iam attach-role-policy --role-name ${ROLE_NAME} --policy-arn arn:aws:iam::aws:policy/AmazonRekognitionFullAccess
 aws iam attach-role-policy --role-name ${ROLE_NAME} --policy-arn arn:aws:iam::aws:policy/AmazonS3FullAccess
+aws iam attach-role-policy --role-name ${ROLE_NAME} --policy-arn arn:aws:iam::aws:policy/CloudWatchLogsFullAccess
 
 # Create the photos bucket
 aws s3 mb s3://$BUCKET_NAME/ --region $REGION


### PR DESCRIPTION
Vladimir

I wasn't able to get the Lambda add function to log anything when coping a file to the S3 bucket via the AWS cli -- as there wasn't any logging I'm not really sure what the problem might have been.  

When I mocked up an event and ran the Lambda add function from the AWS console, the function would run and logging would happen as expected.

Attaching the CloudWatchLogsFullAccess to the IAM role seems to have fixed the problem and is the only change in this pull request.

`aws iam attach-role-policy --role-name ${ROLE_NAME} --policy-arn arn:aws:iam::aws:policy/CloudWatchLogsFullAccess`

tom
