### PR TITLE
Sign-up, confirm user and begin auth flow to get JWT ID token

### DIFF
--- a/setup/setupEnvironment.sh
+++ b/setup/setupEnvironment.sh
@@ -197,12 +197,12 @@ aws es delete-elasticsearch-domain --domain-name ${ES_DOMAIN_NAME}
 EOF
 
 # Replace all of the property values in Properties.kt
-sed  -i 's#REGION_REPLACE_ME#'${REGION}'#g' ../src/main/kotlin/com/budilov/Properties.kt
-sed  -i 's#ACCOUNT_REPLACE_ME#'${ACCOUNT_NUMBER}'#g' ../src/main/kotlin/com/budilov/Properties.kt
-sed  -i 's#COGNITO_POOL_ID_REPLACE_ME#'${COGNITO_POOL_ID}'#g' ../src/main/kotlin/com/budilov/Properties.kt
-sed  -i 's#USER_POOL_ID_REPLACE_ME#'${USER_POOL_ID}'#g' ../src/main/kotlin/com/budilov/Properties.kt
-sed  -i 's#ES_SERVICE_URL_REPLACE_ME#'${ES_ENDPOINT}'#g' ../src/main/kotlin/com/budilov/Properties.kt
-sed  -i 's#BUCKET_REPLACE_ME#'${BUCKET_NAME}'#g' ../src/main/kotlin/com/budilov/Properties.kt
+sed  -i.tmp 's#REGION_REPLACE_ME#'${REGION}'#g' ../src/main/kotlin/com/budilov/Properties.kt
+sed  -i.tmp 's#ACCOUNT_REPLACE_ME#'${ACCOUNT_NUMBER}'#g' ../src/main/kotlin/com/budilov/Properties.kt
+sed  -i.tmp 's#COGNITO_POOL_ID_REPLACE_ME#'${COGNITO_POOL_ID}'#g' ../src/main/kotlin/com/budilov/Properties.kt
+sed  -i.tmp 's#USER_POOL_ID_REPLACE_ME#'${USER_POOL_ID}'#g' ../src/main/kotlin/com/budilov/Properties.kt
+sed  -i.tmp 's#ES_SERVICE_URL_REPLACE_ME#'${ES_ENDPOINT}'#g' ../src/main/kotlin/com/budilov/Properties.kt
+sed  -i.tmp 's#BUCKET_REPLACE_ME#'${BUCKET_NAME}'#g' ../src/main/kotlin/com/budilov/Properties.kt
 
 # Build the code again and update all of the lambda functions
 cd ..
@@ -294,6 +294,6 @@ echo "Remove the picture"
 echo "aws s3 rm s3://${BUCKET_NAME}/usercontent/${COGNITO_POOL_ID}/new-york.jpg"
 echo
 echo "Sample search command (that's after you login and upload a picture using your real Cognito Id). You'll need your JWT_TOKEN_ID as well"
-echo "curl -X POST -H \"Authorization: ${JWT_ID_TOKEN}\" -H \"search-key: building\" -H \"Cache-Control: no-cache\" \"${API_GATEWAY_URL}\""
+echo "curl -X POST -H \"Authorization: ${JWT_ID_TOKEN}\" -H \"search-key: building\" -H \"Cache-Control: no-cache\" \"${API_GATEWAY_URL}/picture/search\""
 echo
 echo

--- a/setup/setupEnvironment.sh
+++ b/setup/setupEnvironment.sh
@@ -241,11 +241,8 @@ aws apigateway delete-rest-api --rest-api-id ${GATEWAY_ID}
 EOF
 
 ## get the JWT_ID_TOKEN
-USERNAME=$(cat /dev/urandom | env LC_CTYPE=C tr -dc "a-zA-Z0-9" | fold -w 8 | head -n 1)
-PASSWORD=$(cat /dev/urandom | env LC_CTYPE=C tr -dc "a-zA-Z0-9@#$%^&()_+~" | fold -w 16 | head -n 1)
 
 
-#USER_POOL_ID="us-east-1_ESkLVL2Vp"
 CLIENT_ID=$(aws cognito-idp list-user-pool-clients --user-pool-id ${USER_POOL_ID} --max-results 3 --query UserPoolClients[0].ClientId --output text)
 
 # 1.5 Enable sign-in API for server-based authentication (ADMIN_NO_SRP_AUTH)
@@ -256,7 +253,10 @@ aws cognito-idp update-user-pool-client --user-pool-id ${USER_POOL_ID} --client-
 fi
 
 # 2. sign-up a user
-
+#USERNAME=$(cat /dev/urandom | env LC_CTYPE=C tr -dc "a-zA-Z0-9" | fold -w 8 | head -n 1)
+#PASSWORD=$(cat /dev/urandom | env LC_CTYPE=C tr -dc "a-zA-Z0-9@#$%^&()_+~" | fold -w 16 | head -n 1)
+USERNAME="jakethedog"
+PASSWORD="P@ssword1"
 aws cognito-idp sign-up --client-id ${CLIENT_ID} --username ${USERNAME} --password ${PASSWORD} --user-attributes '[ { "Name": "email", "Value": "first.last@domain.com" }, { "Name": "phone_number", "Value": "+12485551212" }]'
 
 # 2.5 confirm user
@@ -270,6 +270,8 @@ EOF
 JWT_ID_TOKEN=$(aws cognito-idp admin-initiate-auth  --user-pool-id ${USER_POOL_ID} --client-id ${CLIENT_ID} --cli-input-json file:///tmp/authflow.json --query AuthenticationResult.IdToken --output text)
 
 echo "JWT_ID_TOKEN: " ${JWT_ID_TOKEN}
+
+echo "USER_POOL_ID: " ${USER_POOL_ID}
 
 
 echo "------------"
@@ -286,7 +288,6 @@ echo
 echo "Remove the picture"
 echo "aws s3 rm s3://${BUCKET_NAME}/usercontent/${COGNITO_POOL_ID}/new-york.jpg"
 echo
-echo "Sample search command (that's after you login and upload a picture using your real Cognito Id). You'll need your JWT_TOKEN_ID as well"
-echo "curl -X POST -H \"Authorization: Bearer ${JWT_ID_TOKEN}\" -H \"search-key: building\" -H \"Cache-Control: no-cache\" \"${API_GATEWAY_URL}/picture/search\""
-echo
+echo "Sample search command "
+echo "curl -X POST -H \"Authorization: ${JWT_ID_TOKEN}\" -H \"search-key: Building\" -H \"Cache-Control: no-cache\" \"${API_GATEWAY_URL}/picture/search\""
 echo

--- a/setup/setupEnvironment.sh
+++ b/setup/setupEnvironment.sh
@@ -243,11 +243,7 @@ EOF
 ## get the JWT_ID_TOKEN
 USERNAME=$(cat /dev/urandom | env LC_CTYPE=C tr -dc "a-zA-Z0-9" | fold -w 8 | head -n 1)
 PASSWORD=$(cat /dev/urandom | env LC_CTYPE=C tr -dc "a-zA-Z0-9@#$%^&()_+~" | fold -w 16 | head -n 1)
-#USERNAME="zeke"
-#PASSWORD="P@ssword1"
 
-#echo 'username: ' ${USERNAME}
-#echo 'password: ' ${PASSWORD}
 
 #USER_POOL_ID="us-east-1_ESkLVL2Vp"
 CLIENT_ID=$(aws cognito-idp list-user-pool-clients --user-pool-id ${USER_POOL_ID} --max-results 3 --query UserPoolClients[0].ClientId --output text)
@@ -257,9 +253,6 @@ SRP_AUTH_ENABLED=$(aws cognito-idp describe-user-pool-client --user-pool-id $USE
 
 if [ ! ${SRP_AUTH_ENABLED} ]; then
 aws cognito-idp update-user-pool-client --user-pool-id ${USER_POOL_ID} --client-id ${CLIENT_ID}  --explicit-auth-flows ADMIN_NO_SRP_AUTH
-echo "enabled"
-else
-echo "already enabled"
 fi
 
 # 2. sign-up a user
@@ -294,6 +287,6 @@ echo "Remove the picture"
 echo "aws s3 rm s3://${BUCKET_NAME}/usercontent/${COGNITO_POOL_ID}/new-york.jpg"
 echo
 echo "Sample search command (that's after you login and upload a picture using your real Cognito Id). You'll need your JWT_TOKEN_ID as well"
-echo "curl -X POST -H \"Authorization: ${JWT_ID_TOKEN}\" -H \"search-key: building\" -H \"Cache-Control: no-cache\" \"${API_GATEWAY_URL}/picture/search\""
+echo "curl -X POST -H \"Authorization: Bearer ${JWT_ID_TOKEN}\" -H \"search-key: building\" -H \"Cache-Control: no-cache\" \"${API_GATEWAY_URL}/picture/search\""
 echo
 echo

--- a/setup/setupEnvironment.sh
+++ b/setup/setupEnvironment.sh
@@ -240,6 +240,45 @@ aws apigateway delete-rest-api --rest-api-id ${GATEWAY_ID}
 
 EOF
 
+## get the JWT_ID_TOKEN
+USERNAME=$(cat /dev/urandom | env LC_CTYPE=C tr -dc "a-zA-Z0-9" | fold -w 8 | head -n 1)
+PASSWORD=$(cat /dev/urandom | env LC_CTYPE=C tr -dc "a-zA-Z0-9@#$%^&()_+~" | fold -w 16 | head -n 1)
+#USERNAME="zeke"
+#PASSWORD="P@ssword1"
+
+#echo 'username: ' ${USERNAME}
+#echo 'password: ' ${PASSWORD}
+
+#USER_POOL_ID="us-east-1_ESkLVL2Vp"
+CLIENT_ID=$(aws cognito-idp list-user-pool-clients --user-pool-id ${USER_POOL_ID} --max-results 3 --query UserPoolClients[0].ClientId --output text)
+
+# 1.5 Enable sign-in API for server-based authentication (ADMIN_NO_SRP_AUTH)
+SRP_AUTH_ENABLED=$(aws cognito-idp describe-user-pool-client --user-pool-id $USER_POOL_ID --client-id $CLIENT_ID --query '[contains(UserPoolClient.ExplicitAuthFlows,`ADMIN_NO_SRP_AUTH`)]' --output text)
+
+if [ ! ${SRP_AUTH_ENABLED} ]; then
+aws cognito-idp update-user-pool-client --user-pool-id ${USER_POOL_ID} --client-id ${CLIENT_ID}  --explicit-auth-flows ADMIN_NO_SRP_AUTH
+echo "enabled"
+else
+echo "already enabled"
+fi
+
+# 2. sign-up a user
+
+aws cognito-idp sign-up --client-id ${CLIENT_ID} --username ${USERNAME} --password ${PASSWORD} --user-attributes '[ { "Name": "email", "Value": "first.last@domain.com" }, { "Name": "phone_number", "Value": "+12485551212" }]'
+
+# 2.5 confirm user
+aws cognito-idp admin-confirm-sign-up --user-pool-id ${USER_POOL_ID} --username ${USERNAME}
+
+#3. begin auth flow
+cat << EOF > /tmp/authflow.json
+{ "AuthFlow": "ADMIN_NO_SRP_AUTH", "AuthParameters": { "USERNAME": "${USERNAME}", "PASSWORD": "${PASSWORD}" } }
+EOF
+
+JWT_ID_TOKEN=$(aws cognito-idp admin-initiate-auth  --user-pool-id ${USER_POOL_ID} --client-id ${CLIENT_ID} --cli-input-json file:///tmp/authflow.json --query AuthenticationResult.IdToken --output text)
+
+echo "JWT_ID_TOKEN: " ${JWT_ID_TOKEN}
+
+
 echo "------------"
 echo "You're done!"
 echo "------------"
@@ -249,10 +288,12 @@ grep "=" ../src/main/kotlin/com/budilov/Properties.kt
 echo "-Try out the following commands: -"
 
 echo "Upload a picture"
-echo "aws s3 cp new-york.jpg s3://${BUCKET_NAME}/usercontent/us-east-1:11122233-4455-6677-8888-999999999999/"
-
+echo "aws s3 cp new-york.jpg s3://${BUCKET_NAME}/usercontent/${COGNITO_POOL_ID}/"
+echo
 echo "Remove the picture"
-echo "aws s3 rm s3://${BUCKET_NAME}/usercontent/us-east-1:11122233-4455-6677-8888-999999999999/new-york.jpg"
-
+echo "aws s3 rm s3://${BUCKET_NAME}/usercontent/${COGNITO_POOL_ID}/new-york.jpg"
+echo
 echo "Sample search command (that's after you login and upload a picture using your real Cognito Id). You'll need your JWT_TOKEN_ID as well"
-echo "curl -X POST -H \"Authorization: JWT_TOKEN_ID\"-H \"search-key: building\" -H \"Cache-Control: no-cache\" \"${API_GATEWAY_URL}\""
+echo "curl -X POST -H \"Authorization: ${JWT_ID_TOKEN}\" -H \"search-key: building\" -H \"Cache-Control: no-cache\" \"${API_GATEWAY_URL}\""
+echo
+echo


### PR DESCRIPTION
Creates a user in the previously created cognito identity pool (using the webapp client ID), confirms the user and begins the auth flow to get the ID Token.

This also requires that ADMIN_NO_SRP_AUTH be added to the auth flows of the pool ID.  This modification could probably be moved to the pool creation code.

I added this code to remove the user dependency on using the other Cognito Startup project and to help me keep the auth, pools, users, clientIDs etc straight in my head :-)

